### PR TITLE
update bluebird to cleanup handlers immediately after promise settlement...

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -995,14 +995,16 @@ Promise.prototype._settlePromiseAt = function Promise$_settlePromiseAt(index) {
         }
     }
 
-    // hadron has some long lived promises, which get
-    // then'ed by other short lived objects. those short lived objects
-    // account for very large memory footprints. We want to clean up
-    // these references  as soon as we can.
+    // This version of bluebird used to clean up settlement handlers
+    // after 256 of them were collected.
     //
-    // This version of bluebird used clean up handlers
-    // after 256 of them were collected. newer version changed this to 4
-    // we want them cleaned up immediately - like other promise
+    // this has huge implications for long lived promises, which get
+    // then'ed by some short lived objects. those short lived objects
+    // are no more short lived, and would not get GC'ed untill lots of them
+    // accumulate.
+    //
+    // newer version of bluebird changed this to 4
+    // But we want them cleaned up immediately - like other promise
     // implementations like Q, when etc. lets clean up after (1) handler
     // for more on this read:
     // https://github.com/petkaantonov/bluebird/issues/296


### PR DESCRIPTION
### CHANGE SUMMARY
- HAD-3334 bluebird's delayed handler cleans ups leads to memory leaks.
### CHANGE DETAILS

our version of bluebird does not cleanup promise handlers immediately after promise is fulfilled. It waits for 256 handlers to have gathered before cleanup. Hadron uses some long lived promises - which is very legit usage of promises - which are then'ed by short lived objects. because of bluebird's delayed cleanup all those short lived objects do not get GC'ed. They account for substantial memory footprint. 

This change changes the handler cache size from 256 to 1, now handlers gets cleaned up immediately on fulfillment. 
