### PR TITLE
always queue a GC to prevent memory leaking

### DIFF
--- a/js/browser/bluebird.js
+++ b/js/browser/bluebird.js
@@ -2621,9 +2621,7 @@ Promise.prototype._settlePromiseAt = function Promise$_settlePromiseAt(index) {
         }
     }
 
-    if (index >= 1) {
-        this._queueGC();
-    }
+    this._queueGC();
 };
 
 Promise.prototype._isProxied = function Promise$_isProxied() {

--- a/src/promise.js
+++ b/src/promise.js
@@ -1008,9 +1008,7 @@ Promise.prototype._settlePromiseAt = function Promise$_settlePromiseAt(index) {
     // implementations like Q, when etc. lets clean up after (1) handler
     // for more on this read:
     // https://github.com/petkaantonov/bluebird/issues/296
-    if (index >= 1) {
-        this._queueGC();
-    }
+    this._queueGC();
 };
 
 Promise.prototype._isProxied = function Promise$_isProxied() {


### PR DESCRIPTION
### CHANGE SUMMARY
- index is zero for the first promise, so we're not doing a GC.  This causes all of the main menu view host to be held onto when you're on ContinueWatching, and other similar issues.
- fix is to unconditionally queueGC
