### PR TITLE
preventing call stack capture to save 2% javascript cpu time on firetv

### DIFF
--- a/js/browser/bluebird.js
+++ b/js/browser/bluebird.js
@@ -887,9 +887,6 @@ function subError(nameProperty, defaultMessage) {
         if (!(this instanceof SubError)) return new SubError(message);
         this.message = typeof message === "string" ? message : defaultMessage;
         this.name = nameProperty;
-        if (Promise.GuaranteedStackTraces === true && Error.captureStackTrace) {
-            Error.captureStackTrace(this, this.constructor);
-        }
     }
     inherits(SubError, Error);
     return SubError;

--- a/src/errors.js
+++ b/src/errors.js
@@ -32,9 +32,6 @@ function subError(nameProperty, defaultMessage) {
         if (!(this instanceof SubError)) return new SubError(message);
         this.message = typeof message === "string" ? message : defaultMessage;
         this.name = nameProperty;
-        if (Promise.GuaranteedStackTraces === true && Error.captureStackTrace) {
-            Error.captureStackTrace(this, this.constructor);
-        }
     }
     inherits(SubError, Error);
     return SubError;


### PR DESCRIPTION
### CHANGE SUMMARY
- the main code review for this is here: https://github.com/HBOCodeLabs/Hadron/pull/1536, this is the same change in our bb fork.  Please comment on the other PR unless it's specific to the fork.
