### PR TITLE
optimized the queue sizes

### DIFF
--- a/js/browser/bluebird.js
+++ b/js/browser/bluebird.js
@@ -167,8 +167,8 @@ var tryCatch1 = require("./util.js").tryCatch1;
 function Async() {
     this._isTickUsed = false;
     this._length = 0;
-    this._lateBuffer = new Queue();
-    this._functionBuffer = new Queue(25000 * 3);
+    this._lateBuffer = new Queue(16384);
+    this._functionBuffer = new Queue(2048);
     var self = this;
     this.consumeFunctionBuffer = function Async$consumeFunctionBuffer() {
         self._consumeFunctionBuffer();
@@ -4017,7 +4017,7 @@ Queue.prototype._makeCapacity = function Queue$_makeCapacity() {
 
 Queue.prototype._checkCapacity = function Queue$_checkCapacity(size) {
     if (this._capacity < size) {
-        this._resizeTo(this._capacity << 3);
+        this._resizeTo(this._capacity << 1);
     }
 };
 

--- a/src/async.js
+++ b/src/async.js
@@ -8,11 +8,14 @@ var tryCatch1 = require("./util.js").tryCatch1;
 function Async() {
     this._isTickUsed = false;
     this._length = 0;
-    // The initial sizes were manually determined.
+    // The initial capacities were manually determined.
     // I ran HBO GO under stressful conditions and looked at how large they grew.
     // It should be a better estimate than stock-bluebird (which underestimated
     // _lateBuffer and overestimated _functionBuffer), which will save us memory,
     // GC overhead, and resize cost.
+    //
+    // If another project wants initial capacity to be different we will need to
+    // introduce some sort of configuration here.
     this._lateBuffer = new Queue(16384);
     this._functionBuffer = new Queue(2048);
     var self = this;

--- a/src/async.js
+++ b/src/async.js
@@ -8,8 +8,13 @@ var tryCatch1 = require("./util.js").tryCatch1;
 function Async() {
     this._isTickUsed = false;
     this._length = 0;
-    this._lateBuffer = new Queue();
-    this._functionBuffer = new Queue(25000 * BUFFER_STRIDE);
+    // The initial sizes were manually determined.
+    // I ran HBO GO under stressful conditions and looked at how large they grew.
+    // It should be a better estimate than stock-bluebird (which underestimated
+    // _lateBuffer and overestimated _functionBuffer), which will save us memory,
+    // GC overhead, and resize cost.
+    this._lateBuffer = new Queue(16384);
+    this._functionBuffer = new Queue(2048);
     var self = this;
     //Optimized around the fact that no arguments
     //need to be passed

--- a/src/queue.js
+++ b/src/queue.js
@@ -91,7 +91,8 @@ Queue.prototype._makeCapacity = function Queue$_makeCapacity() {
 
 Queue.prototype._checkCapacity = function Queue$_checkCapacity(size) {
     if (this._capacity < size) {
-        this._resizeTo(this._capacity << 3);
+        // If we need to resize, double it.
+        this._resizeTo(this._capacity << 1);
     }
 };
 


### PR DESCRIPTION
### CHANGE SUMMARY
* HAD-4721 Optimize bluebird queue sizes based on our apps actual usage.
* Bluebird underestimated the eventual _lateBuffer size by a factor of 1024
* Bluebird overestimated the eventual _functionBuffer size by a factor of 64
* The new values and growth factor better reflect our apps usage of bluebird.

### CHANGE DETAILS
* I ran HBO in the browser and used it rapidly to see where these queue sizes ended up.
* Having a queue too small causes resizing cost.  I noticed this on hobbit where it took >100ms to resize the _lateBuffer from 8k to 16k.
* Having a queue too large uses up memory (_functionBuffer was 5% of the total JS heap) and probably makes the GC take longer (although that's hard to measure due to variability).