### PR TITLE
sentinel property for stackTraceLimit

### DIFF
--- a/js/browser/bluebird.js
+++ b/js/browser/bluebird.js
@@ -592,6 +592,12 @@ var captureStackTrace = (function stackDetection() {
             configurable: false,
             value: 25
         });
+        defineProperty(Error, "__bluebirdStackTraceLimit__", {
+            writable: true,
+            enumerable: false,
+            configurable: false,
+            value: true
+        });
         rtraceline = /@/;
         var rline = /[@\n]/;
 

--- a/src/captured_trace.js
+++ b/src/captured_trace.js
@@ -174,6 +174,14 @@ var captureStackTrace = (function stackDetection() {
             configurable: false,
             value: 25
         });
+        // the previous property definition is messing up our detection of native support of stack trace limits
+        // define another property to ensure we know this is fake...
+        defineProperty(Error, "__bluebirdStackTraceLimit__", {
+            writable: true,
+            enumerable: false,
+            configurable: false,
+            value: true
+        });
         rtraceline = /@/;
         var rline = /[@\n]/;
 


### PR DESCRIPTION
adding sentinel property so we can better detect we're in an environment that doesn't actually support stackTraceLimit.  Our tests use the presence of the stackTraceLimit property to make some assumptions about what we can do with exceptions.  Our fork of bluebird is old enough that they were still doing that (updated bluebird does not use that method).  Tests that previously checked for that property will also check for the bluebird property.

@dpwolfe or @jvaleske ?