### PR TITLE
batch function buffer consumption using external dispatcher

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -41,6 +41,10 @@ var setExternalDispatcher = function Promise$setExternalDispatcher(dispatcher) {
     async.externalDispatcher = dispatcher;
 };
 
+var setBatchSize = function Promise$setBatchSize(batchSize) {
+    async.batchSize = batchSize;
+}
+
 function isPromise(obj) {
     if (obj === void 0) return false;
     return obj instanceof Promise;
@@ -1227,6 +1231,7 @@ if (!CapturedTrace.isSupported()) {
 
 Promise._makeSelfResolutionError = makeSelfResolutionError;
 Promise.setExternalDispatcher = setExternalDispatcher;
+Promise.setBatchSize = setBatchSize;
 require("./finally.js")(Promise, NEXT_FILTER);
 require("./direct_resolve.js")(Promise);
 require("./thenables.js")(Promise, INTERNAL);


### PR DESCRIPTION
### CHANGE SUMMARY
* HAD-13021 bluebird processes function buffer all-at-once leading to long frames

### CHANGE DETAIL
* _consumeFunctionBuffer runs through everything on the buffer in a while loop. This change adds a "batchSize" and requests a callback on the externalDispatcher if the batchSize is exceeded instead of processing all work items in a loop. 