### PR TITLE
allow custom setTimeout function

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -17,7 +17,7 @@ function Async() {
     this.drainQueues = function () {
         self._drainQueues();
     };
-    this._setTimeout = undefined;
+    this._customSetTimeout = undefined;
     this._schedule = schedule;
 }
 
@@ -29,14 +29,14 @@ Async.prototype.setScheduler = function(fn) {
 };
 
 Async.prototype.setTimeoutScheduler = function(setTimeoutFn) {
-    var prev = this._setTimeout;
-    this._setTimeout = setTimeoutFn;
+    var prev = this._customSetTimeout;
+    this._customSetTimeout = setTimeoutFn;
     return prev;
 };
 
-// returns inbuilt timeout function, or custome one if set.
+// returns built-in timeout function, or custom one if set.
 Async.prototype.getTimeoutFn = function () {
-    return this._setTimeout || setTimeout;
+    return this._customSetTimeout || setTimeout;
 };
 
 Async.prototype.hasCustomScheduler = function() {

--- a/src/async.js
+++ b/src/async.js
@@ -17,6 +17,7 @@ function Async() {
     this.drainQueues = function () {
         self._drainQueues();
     };
+    this._setTimeout = undefined;
     this._schedule = schedule;
 }
 
@@ -25,6 +26,17 @@ Async.prototype.setScheduler = function(fn) {
     this._schedule = fn;
     this._customScheduler = true;
     return prev;
+};
+
+Async.prototype.setTimeoutScheduler = function(setTimeoutFn) {
+    var prev = this._setTimeout;
+    this._setTimeout = setTimeoutFn;
+    return prev;
+};
+
+// returns inbuilt timeout function, or custome one if set.
+Async.prototype.getTimeoutFn = function () {
+    return this._setTimeout || setTimeout;
 };
 
 Async.prototype.hasCustomScheduler = function() {
@@ -62,6 +74,7 @@ Async.prototype.throwLater = function(fn, arg) {
         arg = fn;
         fn = function () { throw arg; };
     }
+    var setTimeout = this.getTimeoutFn();
     if (typeof setTimeout !== "undefined") {
         setTimeout(function() {
             fn(arg);
@@ -103,6 +116,7 @@ if (!util.hasDevTools) {
         if (this._trampolineEnabled) {
             AsyncInvokeLater.call(this, fn, receiver, arg);
         } else {
+            var setTimeout = this.getTimeoutFn();
             this._schedule(function() {
                 setTimeout(function() {
                     fn.call(receiver, arg);

--- a/src/promise.js
+++ b/src/promise.js
@@ -165,6 +165,8 @@ Promise.prototype.error = function (fn) {
     return this.caught(util.originatesFromRejection, fn);
 };
 
+Promise.getNewLibraryCopy = module.exports;
+
 Promise.is = function (val) {
     return val instanceof Promise;
 };
@@ -206,14 +208,11 @@ Promise.reject = Promise.rejected = function (reason) {
     return ret;
 };
 
-Promise.setScheduler = function(fn, setTimeoutFn) {
+Promise.setScheduler = function(fn) {
     if (typeof fn !== "function") {
         throw new TypeError(FUNCTION_ERROR + util.classString(fn));
     }
-    if (setTimeoutFn !== undefined && typeof setTimeoutFn !== "function") {
-        throw new TypeError(FUNCTION_ERROR + util.classString(setTimeoutFn));
-    }
-    return async.setScheduler(fn, setTimeoutFn);
+    return async.setScheduler(fn);
 };
 
 Promise.setTimeoutScheduler = function(setTimeoutFn) {

--- a/src/promise.js
+++ b/src/promise.js
@@ -165,8 +165,6 @@ Promise.prototype.error = function (fn) {
     return this.caught(util.originatesFromRejection, fn);
 };
 
-Promise.getNewLibraryCopy = module.exports;
-
 Promise.is = function (val) {
     return val instanceof Promise;
 };
@@ -208,11 +206,21 @@ Promise.reject = Promise.rejected = function (reason) {
     return ret;
 };
 
-Promise.setScheduler = function(fn) {
+Promise.setScheduler = function(fn, setTimeoutFn) {
     if (typeof fn !== "function") {
         throw new TypeError(FUNCTION_ERROR + util.classString(fn));
     }
-    return async.setScheduler(fn);
+    if (setTimeoutFn !== undefined && typeof setTimeoutFn !== "function") {
+        throw new TypeError(FUNCTION_ERROR + util.classString(setTimeoutFn));
+    }
+    return async.setScheduler(fn, setTimeoutFn);
+};
+
+Promise.setTimeoutScheduler = function(setTimeoutFn) {
+    if (setTimeoutFn !== undefined && typeof setTimeoutFn !== "function") {
+        throw new TypeError(FUNCTION_ERROR + util.classString(setTimeoutFn));
+    }
+    return async.setTimeoutScheduler(setTimeoutFn);
 };
 
 Promise.prototype._then = function (
@@ -749,12 +757,21 @@ function deferResolve(v) {this.promise._resolveCallback(v);}
 function deferReject(v) {this.promise._rejectCallback(v, false);}
 
 Promise.defer = Promise.pending = function() {
-    debug.deprecated("Promise.defer", "new Promise");
+    // TODO HAD-15960 remove shim for deprecated APIs,
+    //      and update callers  to use recommended API
+    // will fix the defer instances with new promise later.
+    // debug.deprecated("Promise.defer", "new Promise");
     var promise = new Promise(INTERNAL);
     return {
         promise: promise,
         resolve: deferResolve,
-        reject: deferReject
+        reject: deferReject,
+        // TODO HAD-15960 remove shim for deprecated APIs,
+        //      and update callers  to use recommended API
+        fulfill: deferResolve,
+        cancel: function () {
+            return this.promise.cancel();
+        }
     };
 };
 

--- a/src/timers.js
+++ b/src/timers.js
@@ -2,6 +2,7 @@
 module.exports = function(Promise, INTERNAL, debug) {
 var util = require("./util");
 var TimeoutError = Promise.TimeoutError;
+var async = Promise._async;
 
 function HandleWrapper(handle)  {
     this.handle = handle;
@@ -23,6 +24,8 @@ var delay = Promise.delay = function (ms, value) {
         }
     } else {
         ret = new Promise(INTERNAL);
+
+        var setTimeout = async.getTimeoutFn();
         handle = setTimeout(function() { ret._fulfill(); }, +ms);
         if (debug.cancellation()) {
             ret._setOnCancel(new HandleWrapper(handle));
@@ -70,6 +73,7 @@ Promise.prototype.timeout = function (ms, message) {
     ms = +ms;
     var ret, parent;
 
+    var setTimeout = async.getTimeoutFn();
     var handleWrapper = new HandleWrapper(setTimeout(function timeoutTimeout() {
         if (ret.isPending()) {
             afterTimeout(ret, message, parent);

--- a/test/mocha/schedule.js
+++ b/test/mocha/schedule.js
@@ -44,5 +44,16 @@ describe("schedule", function () {
                 assert.fail();
             });
         });
+
+        describe("Promise.setTimeoutScheduler", function() {
+            it("should throw for non function", function() {
+                try {
+                    Promise.setTimeoutScheduler({});
+                } catch (e) {
+                    return Promise.resolve();
+                }
+                assert.fail();
+            });
+        });
     }
 });

--- a/test/mocha/timers.js
+++ b/test/mocha/timers.js
@@ -191,7 +191,7 @@ describe("delay", function () {
 
     it("should call custom timeout function", function() {
         var custom = false;
-        var customTimeOutFunction = function  (fn, ms) {
+        var customTimeOutFunction = function (fn, ms) {
             custom = true;
             assert(ms === 3);
             setTimeout(fn, ms);

--- a/test/mocha/timers.js
+++ b/test/mocha/timers.js
@@ -105,7 +105,6 @@ describe("timeout", function () {
                 globalObject.setTimeout = globalObject.oldSetTimeout;
                 globalObject.clearTimeout = globalObject.oldClearTimeout;
                 expectedHandleType = typeof (globalObject.setTimeout(function(){}, 1));
-                expectedHandleType = "number";
             });
 
             after(function() {
@@ -122,7 +121,7 @@ describe("timeout", function () {
                 };
 
                 return Promise.delay(1).timeout(10000).then(function() {
-                    // assert.strictEqual(expectedHandleType, handleType);
+                    assert.strictEqual(expectedHandleType, handleType);
                 });
             });
 
@@ -137,7 +136,7 @@ describe("timeout", function () {
                 return new Promise(function(_, reject) {
                     setTimeout(reject, 10);
                 }).timeout(10000).then(null, function() {
-                    // assert.strictEqual(expectedHandleType, handleType);
+                    assert.strictEqual(expectedHandleType, handleType);
                 });
             });
         })

--- a/test/mocha/timers.js
+++ b/test/mocha/timers.js
@@ -105,6 +105,7 @@ describe("timeout", function () {
                 globalObject.setTimeout = globalObject.oldSetTimeout;
                 globalObject.clearTimeout = globalObject.oldClearTimeout;
                 expectedHandleType = typeof (globalObject.setTimeout(function(){}, 1));
+                expectedHandleType = "number";
             });
 
             after(function() {
@@ -121,7 +122,7 @@ describe("timeout", function () {
                 };
 
                 return Promise.delay(1).timeout(10000).then(function() {
-                    assert.strictEqual(expectedHandleType, handleType);
+                    // assert.strictEqual(expectedHandleType, handleType);
                 });
             });
 
@@ -136,7 +137,7 @@ describe("timeout", function () {
                 return new Promise(function(_, reject) {
                     setTimeout(reject, 10);
                 }).timeout(10000).then(null, function() {
-                    assert.strictEqual(expectedHandleType, handleType);
+                    // assert.strictEqual(expectedHandleType, handleType);
                 });
             });
         })
@@ -189,4 +190,17 @@ describe("delay", function () {
             });
     });
 
+    it("should call custom timeout function", function() {
+        var custom = false;
+        var customTimeOutFunction = function  (fn, ms) {
+            custom = true;
+            assert(ms === 3);
+            setTimeout(fn, ms);
+        }
+        var old = Promise.setTimeoutScheduler(customTimeOutFunction);
+        return Promise.delay(3).then(function () {
+            assert(custom === true);
+            Promise.setTimeoutScheduler(old);
+        });
+    });
 });


### PR DESCRIPTION
### SUMMARY
* [HAD-15961](https://youtrack.hbo.com/youtrack/issue/HAD-15961) support external dispatcher for 
setTimeout
* [HAD-15959](https://youtrack.hbo.com/youtrack/issue/HAD-15959) shim deprecated bluebird APIs

### DETAILS

notice that this PR is against bluebird3 branch which is basically same code as upstream origin (https://github.com/petkaantonov/bluebird). 

Here, I am using bluebird3 as a staging branch for our customization of bluebird 3, and once ready will merge this branch into HBOCodeLabs/bluebird/master 

1) support for custom setTimeout
Bluebird 3x added support for custom dispatcher, but didn't extend it to custom setTimeout. It does special case setTimeout depending on environment, (node v/s browser) but does not allow callers to customize it. This change allows callers  to customize setTimeout function used by bluebird.  

2) shim for deprecated APIs
bluebird 3 removed some APIs that  our codebase uses. changing all the instances of deprecated API is bigger task that would be done as part of (HAD-15960 remove shim for deprecated APIs, and update callers  to use recommended API) But in the interim, we this change adds shims for those deprecated apis, so that hadron can be tested against bluebird3 without much changes.

### REVIEWERS
- [x]  Framework Team  ( @finnigantime )

### TEST
added a test for additional functionality, and existing tests continue to pass.
