### PR TITLE
remove debugger only code path from bluebird

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -363,9 +363,15 @@ var ret = {
     markAsOriginatingFromRejection: markAsOriginatingFromRejection,
     classString: classString,
     copyDescriptors: copyDescriptors,
-    hasDevTools: false,
+    // bluebird behaves bit differently when running in chrome debugger
+    // its inconvient as some bugs would repro only when not running debugger.
+    // turning off the feature.
+    // but we should consider controlling this flag from build environemnt
+    // to flesh out timing bugs
+    // TODO: HAD-1673 Add artificial delay to promises to weed out timing issues causing test instability
     // hasDevTools: typeof chrome !== "undefined" && chrome &&
     //              typeof chrome.loadTimes === "function",
+    hasDevTools: false,
     isNode: isNode,
     env: env,
     global: globalObject,

--- a/src/util.js
+++ b/src/util.js
@@ -363,8 +363,9 @@ var ret = {
     markAsOriginatingFromRejection: markAsOriginatingFromRejection,
     classString: classString,
     copyDescriptors: copyDescriptors,
-    hasDevTools: typeof chrome !== "undefined" && chrome &&
-                 typeof chrome.loadTimes === "function",
+    hasDevTools: false,
+    // hasDevTools: typeof chrome !== "undefined" && chrome &&
+    //              typeof chrome.loadTimes === "function",
     isNode: isNode,
     env: env,
     global: globalObject,


### PR DESCRIPTION
Note: This PR is against a staging branch...bluebird3, and not master. The staging branch will merge into master later when all the changes in Bluebird as well as Hadron repo are fully baked. 
 
Bluebird 3 behaves differently when running under chrome debugger. This makes it really difficult to debug issues that only repros w/o debugger! to keep things predictable I am turning off this special code path. 

Basically with debugger available BlueBird decided to execute the code w/o adding it to the taskpool, where as when not running in debugger it goes into task pool for processing later. With this change we won't see nice callstack when running under debugger, but I think its better this way, since that nice callstack was artificial  anyways.