### PR TITLE
remove top line if statement from bluebird3 generated file

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -368,7 +368,8 @@ var ret = {
     // turning off the feature.
     // but we should consider controlling this flag from build environemnt
     // to flesh out timing bugs
-    // TODO: HAD-1673 Add artificial delay to promises to weed out timing issues causing test instability
+    // TODO: HAD-1673 Add artificial delay to promises to weed out
+    // timing issues causing test instability
     // hasDevTools: typeof chrome !== "undefined" && chrome &&
     //              typeof chrome.loadTimes === "function",
     hasDevTools: false,

--- a/tools/build.js
+++ b/tools/build.js
@@ -224,9 +224,9 @@ function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, npmPackage,
 
                     src = src + alias;
 
-                    // enclose source inside a function
-                    // enclosure to prevent "top line if statement"
-                    //
+                    // hadron likes all code inside function enclosures.
+                    // https://github.com/HBOCodeLabs/Hadron/blob/master/build_env/tasks/grunt-postprocess.js#L382
+                    // enclose evrything in function enclosures.
                     var pre =  "(function () {\n";
                     var post = "\n})();\n";
                     src = pre + src + post;

--- a/tools/build.js
+++ b/tools/build.js
@@ -215,12 +215,22 @@ function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, npmPackage,
                 });
                 return Promise.promisify(b.bundle, b)().then(function(src) {
                     var alias = "\
-                    ;if (typeof window !== 'undefined' && window !== null) {       \
-                        window.P = window.Promise;                                 \
-                    } else if (typeof self !== 'undefined' && self !== null) {     \
-                        self.P = self.Promise;                                     \
-                    }";
+                    \n;if (typeof window !== 'undefined' && window !== null) {       \
+                    \n    window.P = window.Promise;                                 \
+                    \n} else if (typeof self !== 'undefined' && self !== null) {     \
+                    \n    self.P = self.Promise;                                     \
+                    \n}                                                              \
+                    \n";
+
                     src = src + alias;
+
+                    // enclose source inside a function
+                    // enclosure to prevent "top line if statement"
+                    //
+                    var pre =  "(function () {\n";
+                    var post = "\n})();\n";
+                    src = pre + src + post;
+
                     src = src.replace(/\brequire\b/g, "_dereq_");
                     var minWrite, write;
                     if (minify) {


### PR DESCRIPTION
# change
[https://youtrack.hbo.com/youtrack/issue/HADINF-4854] make exception for bluebird for " unrecognized top-level statement: IfStatement Use --force to continue. "

# details.
bluebird3's generated file contained a top level if statement. Hadron's build process does not like top level statements (it prefers everything enclosed inside a function call). This fix updates the bluebird build script to enclose the if statement inside immediate function call. 

Note: this diff is against bluebird3 branch that is a staging branch for bluebird work. It will merge against master later. 


