### PR TITLE
instrumentation to track promises for unit tests

### DIFF
--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -111,6 +111,10 @@ Promise.onUnhandledRejectionHandled = function (fn) {
                                  : undefined;
 };
 
+Promise.enableHadronTestTracking = function (enable) {
+    config.trackHadronTest = enable;
+};
+
 var disableLongStackTraces = function() {};
 Promise.longStackTraces = function () {
     if (async.haveItemsQueued() && !config.longStackTraces) {
@@ -230,6 +234,11 @@ Promise.config = function(opts) {
             disableLongStackTraces();
         }
     }
+
+    if ("trackHadronTest" in opts) {
+        Promise.enableHadronTestTracking(opts.trackHadronTest);
+    }
+
     if ("warnings" in opts) {
         var warningsOption = opts.warnings;
         config.warnings = !!warningsOption;
@@ -852,7 +861,11 @@ var config = {
     warnings: warnings,
     longStackTraces: false,
     cancellation: false,
-    monitoring: false
+    monitoring: false,
+    // when enabled, this will track hadron tests
+    // to make sure the promise created by a test
+    // do not settle after test has finished.
+    trackHadronTest: false
 };
 
 if (longStackTraces) Promise.longStackTraces();
@@ -869,6 +882,9 @@ return {
     },
     monitoring: function() {
         return config.monitoring;
+    },
+    trackHadronTest: function () {
+        return config.trackHadronTest;
     },
     propagateFromFunction: function() {
         return propagateFromFunction;

--- a/src/promise.js
+++ b/src/promise.js
@@ -83,10 +83,10 @@ function Promise(executor) {
     if (debug.trackHadronTest()) {
         // remember the hadron test that created this promise
         //
-        // NOTE: global is passed down
+        // NOTE: _global is passed down
         // by enclosed function which is added later
         // by build process (tools/build.js!buildBrowser)
-        this.hadronTest = _global.hadronTest;
+        this.currentHadronTest = _global.currentHadronTest;
     }
 }
 
@@ -734,8 +734,9 @@ Promise.prototype._settlePromises = function () {
     var bitField = this._bitField;
     var len = BIT_FIELD_READ(LENGTH_MASK);
 
-    if (this.hadronTest !== undefined && _global.hadronTest !== this.hadronTest) {
-        throw new Error("settling promise created by: " + this.hadronTest + ", inside:" + _global.hadronTest);
+    if (this.currentHadronTest !== undefined && _global.currentHadronTest !== this.currentHadronTest) {
+        throw new Error("settling promise created by: " + this.currentHadronTest + ", inside:" + _global.currentHadronTest +
+            ". Promises should resolve during the test that created them to avoid timing-related bugs. ");
     }
 
     if (len > 0) {

--- a/src/promise.js
+++ b/src/promise.js
@@ -79,6 +79,15 @@ function Promise(executor) {
     }
     this._promiseCreated();
     this._fireEvent("promiseCreated", this);
+
+    if (debug.trackHadronTest()) {
+        // remember the hadron test that created this promise
+        //
+        // NOTE: global is passed down
+        // by enclosed function which is added later
+        // by build process (tools/build.js!buildBrowser)
+        this.hadronTest = _global.hadronTest;
+    }
 }
 
 Promise.prototype.toString = function () {
@@ -724,6 +733,10 @@ Promise.prototype._rejectPromises = function (len, reason) {
 Promise.prototype._settlePromises = function () {
     var bitField = this._bitField;
     var len = BIT_FIELD_READ(LENGTH_MASK);
+
+    if (this.hadronTest !== undefined && _global.hadronTest !== this.hadronTest) {
+        throw new Error("settling promise created by: " + this.hadronTest + ", inside:" + _global.hadronTest);
+    }
 
     if (len > 0) {
         if (BIT_FIELD_CHECK(IS_REJECTED_OR_CANCELLED)) {

--- a/tools/build.js
+++ b/tools/build.js
@@ -226,9 +226,9 @@ function buildBrowser(sources, dir, tmpDir, depsRequireCode, minify, npmPackage,
 
                     // hadron likes all code inside function enclosures.
                     // https://github.com/HBOCodeLabs/Hadron/blob/master/build_env/tasks/grunt-postprocess.js#L382
-                    // enclose evrything in function enclosures.
-                    var pre =  "(function () {\n";
-                    var post = "\n})();\n";
+                    // enclose everything in function enclosures.
+                    var pre =  "(function (_global) {\n";
+                    var post = "\n})(this);\n";
                     src = pre + src + post;
 
                     src = src.replace(/\brequire\b/g, "_dereq_");


### PR DESCRIPTION
### details

I spent long time tracking down a bad test that was leaking promises into other tests. This instrumentation finally caught the culprit. Thought it would be useful to check it in. 

Basically with this change when  ```trackHadronTests``` is set bluebird would associated each promise to the unit test that created it. and would throw if it is settled during some other test.

NOTE: this is not merging into master, but a staging branch that is getting ready for Bluebird3.