### PR TITLE
more instrumentation + a workaround for safari issue.

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -88,6 +88,7 @@ function Promise(executor) {
         // by enclosed function which is added later
         // by build process (tools/build.js!buildBrowser)
         this.currentHadronTest = _global.currentHadronTest;
+        this.creationStack     = new Error().stack;
     }
 }
 
@@ -742,9 +743,11 @@ Promise.prototype._settlePromises = function () {
         // by build process (tools/build.js!buildBrowser)
         _global.currentHadronTest !== this.currentHadronTest) {
         throw new Error(
-            "settling promise created by: " + this.currentHadronTest +
-            ", inside:" + _global.currentHadronTest + ". " +
-            "Promises should resolve during the test that created them " +
+            "Promise was created by test : " + this.currentHadronTest +
+            "But was settled during      : " + _global.currentHadronTest +
+            "\nStack @ creation:\n" +
+            this.creationStack +
+            "\nPromises should resolve during the test that created them " +
             "to avoid timing-related bugs.");
     }
 

--- a/src/props.js
+++ b/src/props.js
@@ -19,9 +19,16 @@ var mapToEntries = (function() {
     }
 
     // NOTE: this used to be named function
-    // but making it anonymous to make safari
-    // happy. safari did not like
-    // optimized/mangled output of this named function.
+    // but making it anonymous to make safari happy.
+    // safari has a bug:
+    // Mangling named functions in strict mode can cause syntax errors in Safari
+    // https://github.com/mishoo/UglifyJS2/issues/179
+    // Safari was failing to load this code as generated code looked like:
+    // return function n(n) {
+    //     ...
+    // }
+    // there is no reason for this function to be named. so workaround is
+    // making it anonymous.
     return function (map) {
         size = map.size;
         index = 0;

--- a/src/props.js
+++ b/src/props.js
@@ -18,7 +18,11 @@ var mapToEntries = (function() {
         index++;
     }
 
-    return function mapToEntries(map) {
+    // NOTE: this used to be named function
+    // but making it anonymous to make safari
+    // happy. safari did not like
+    // optimized/mangled output of this named function.
+    return function (map) {
         size = map.size;
         index = 0;
         var ret = new Array(map.size * 2);


### PR DESCRIPTION
## details
1. I recently added instrumentation to catch cases where promise created by test 1 is resolved during test 2. I encountered issues where it was not clear which promise it was that was getting resolved. I added more instrumentation for this, now for such cases we would print the callstack of the promise creation.

2. bluebird lib is added to our app.js and is mangled by requirejs. There is a bug in safari (https://github.com/mishoo/UglifyJS2/issues/179) that did not like the mangled code. I have workaround the issue here.