### PR TITLE
support for limiting the queue processing in batches

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -242,6 +242,14 @@ Promise.setTimeoutScheduler = function(setTimeoutFn) {
     return async.setTimeoutScheduler(setTimeoutFn);
 };
 
+Promise.setBatchSize = function(batchSize) {
+    if (typeof batchSize !== "number" || batchSize <= 0) {
+        throw new TypeError("batchSize must be a positive number: " +
+            util.classString(batchSize));
+    }
+    return async.setBatchSize(batchSize);
+};
+
 Promise.prototype._then = function (
     didFulfill,
     didReject,

--- a/test/mocha/schedule.js
+++ b/test/mocha/schedule.js
@@ -55,5 +55,43 @@ describe("schedule", function () {
                 assert.fail();
             });
         });
+
+        describe("Promise.setBatchSize", function() {
+            it("should throw for non number", function() {
+                try {
+                    Promise.setBatchSize("foo");
+                } catch (e) {
+                    return Promise.resolve();
+                }
+                assert.fail();
+            });
+
+            it("should throw for batchsize of zero", function() {
+                try {
+                    Promise.setBatchSize(0);
+                } catch (e) {
+                    return Promise.resolve();
+                }
+                assert.fail();
+            });
+
+            it("should throw for negative batchsize", function() {
+                try {
+                    Promise.setBatchSize(-7);
+                } catch (e) {
+                    return Promise.resolve();
+                }
+                assert.fail();
+            });
+
+            it("should not throw for positive batchsize", function() {
+                try {
+                    Promise.setBatchSize(5);
+                } catch (e) {
+                    assert.fail();
+                }
+                return Promise.resolve();
+            });
+        });
     }
 });


### PR DESCRIPTION
# change 
in bluebird 2, we added support to limit the work that happens in one frame. 
(see https://github.com/HBOCodeLabs/bluebird/pull/14)

This change adds the same functionality to bluebird 3. It will be used by hadron to limit the batchsize.