### PR TITLE
Add promise.debugName and broaden "current test matches" check

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -708,6 +708,8 @@ Promise.prototype._fulfill = function (value) {
         } else {
             async.settlePromises(this);
         }
+    } else if (debug.trackHadronTest()) {
+        this._verifyCurrentTestMatches();
     }
 };
 
@@ -726,6 +728,9 @@ Promise.prototype._reject = function (reason) {
         async.settlePromises(this);
     } else {
         this._ensurePossibleRejectionHandled();
+        if (debug.trackHadronTest()) {
+            this._verifyCurrentTestMatches();
+        }
     }
 };
 
@@ -749,10 +754,7 @@ Promise.prototype._rejectPromises = function (len, reason) {
     }
 };
 
-Promise.prototype._settlePromises = function () {
-    var bitField = this._bitField;
-    var len = BIT_FIELD_READ(LENGTH_MASK);
-
+Promise.prototype._verifyCurrentTestMatches = function () {
     if (this.currentHadronTest !== undefined &&
         /*jshint -W117*/
         // NOTE: _global is passed down
@@ -760,14 +762,23 @@ Promise.prototype._settlePromises = function () {
         // by build process (tools/build.js!buildBrowser)
         _global.currentHadronTest !== this.currentHadronTest) {
         throw new Error(
-            "Promise was created by test : " + this.currentHadronTest +
-            "But was settled during      : " + _global.currentHadronTest +
+            "Promise (tag=" + this.tag + ") was created by test: " + this.currentHadronTest +
+            "but was settled during: " + _global.currentHadronTest +
             "\nStack @ creation:" +
             "\n==========================\n" +
             this.creationStack +
             "\n==========================\n" +
             "\nPromises should resolve during the test that created them " +
             "to avoid timing-related bugs.");
+    }
+};
+
+Promise.prototype._settlePromises = function () {
+    var bitField = this._bitField;
+    var len = BIT_FIELD_READ(LENGTH_MASK);
+
+    if (debug.trackHadronTest()) {
+        this._verifyCurrentTestMatches();
     }
 
     if (len > 0) {

--- a/src/promise.js
+++ b/src/promise.js
@@ -761,9 +761,13 @@ Promise.prototype._verifyCurrentTestMatches = function () {
         // by enclosed function which is added later
         // by build process (tools/build.js!buildBrowser)
         _global.currentHadronTest !== this.currentHadronTest) {
+        // Note: add the .debugName expando property to Promise instances to identify them uniquely
+        // and help figure out which particular promise is causing a violation.
         throw new Error(
-            "Promise (tag=" + this.tag + ") was created by test: " + this.currentHadronTest +
-            "but was settled during: " + _global.currentHadronTest +
+            "Promise (debugName=" + this.debugName + ") was created by test: " +
+            this.currentHadronTest + " but was settled during: " +
+            _global.currentHadronTest + " with value:\n" +
+            JSON.stringify(this._settledValue()) +
             "\nStack @ creation:" +
             "\n==========================\n" +
             this.creationStack +


### PR DESCRIPTION
- Adds promise.debugName to the failure message for when a promise resolves outside of the test where it was created. Set this expando property on a promise instance to help with promise identification (helpful if longStackTraces is turned off or if the stack traces are from an optimizied/minified file).
- Adds the "current test matches" check to a couple more promise resolution codepaths.