### PR TITLE
Add ability to dynamically toggle longStackTraces

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -11,7 +11,6 @@ function Async() {
     this._isTickUsed = false;
     this._lateQueue = new Queue(LATE_QUEUE_CAPACITY);
     this._normalQueue = new Queue(NORMAL_QUEUE_CAPACITY);
-    this._haveDrainedQueues = false;
     this._trampolineEnabled = true;
     var self = this;
     this.drainQueues = function () {
@@ -65,10 +64,11 @@ Async.prototype.disableTrampolineIfNecessary = function() {
     }
 };
 
-Async.prototype.haveItemsQueued = function () {
-    return this._isTickUsed || this._haveDrainedQueues;
+Async.prototype.areItemsQueued = function () {
+    var areItemsQueued = this._normalQueue.length() > 0 || this._lateQueue.length() > 0;
+    ASSERT(this._isTickUsed === false || areItemsQueued);
+    return areItemsQueued;
 };
-
 
 Async.prototype.fatalError = function(e, isNode) {
     if (isNode) {
@@ -192,17 +192,24 @@ Async.prototype._drainQueues = function (itemsToProcess) {
     ASSERT(this._isTickUsed);
     itemsToProcess = this._drainQueue(this._normalQueue, itemsToProcess);
     this._reset();
-    this._haveDrainedQueues = true;
     this._drainQueue(this._lateQueue, itemsToProcess);
 
-    if (this._normalQueue.length() > 0 || this._lateQueue.length() > 0) {
+    if (this.areItemsQueued()) {
         // couldn't drain the queue this time
         // schedule nother drain.
         this._queueTick();
     }
 };
 
+Async.prototype._fullyDrainQueues = function () {
+    this._drainQueue(this._normalQueue, this._normalQueue.length());
+    this._reset();
+    this._drainQueue(this._lateQueue, this._lateQueue.length());
+    ASSERT(!this.areItemsQueued());
+};
+
 Async.prototype._queueTick = function () {
+    ASSERT(this.areItemsQueued());
     if (!this._isTickUsed) {
         this._isTickUsed = true;
         this._schedule(this.drainQueues);

--- a/src/constants.js
+++ b/src/constants.js
@@ -122,7 +122,7 @@ CONSTANT(CONSTRUCT_ERROR_INVOCATION, "the promise constructor cannot be invoked 
     See http://goo.gl/MqrFmX\n");
 CONSTANT(NOT_GENERATOR_ERROR, "generatorFunction must be a function\n\n\
     See http://goo.gl/MqrFmX\n");
-CONSTANT(LONG_STACK_TRACES_ERROR, "cannot enable long stack traces after promises have been created\n\n\
+CONSTANT(LONG_STACK_TRACES_ERROR, "cannot enable long stack traces while promises are in use\n\n\
     See http://goo.gl/MqrFmX\n");
 CONSTANT(INSPECTION_VALUE_ERROR, "cannot get fulfillment value of a non-fulfilled promise\n\n\
     See http://goo.gl/MqrFmX\n");

--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -117,7 +117,7 @@ Promise.enableHadronTestTracking = function (enable) {
 
 var disableLongStackTraces = function() {};
 Promise.longStackTraces = function () {
-    if (async.haveItemsQueued() && !config.longStackTraces) {
+    if (async.areItemsQueued() && !config.longStackTraces) {
         throw new Error(LONG_STACK_TRACES_ERROR);
     }
     if (!config.longStackTraces && longStackTracesIsSupported()) {
@@ -125,7 +125,7 @@ Promise.longStackTraces = function () {
         var Promise_attachExtraTrace = Promise.prototype._attachExtraTrace;
         config.longStackTraces = true;
         disableLongStackTraces = function() {
-            if (async.haveItemsQueued() && !config.longStackTraces) {
+            if (async.areItemsQueued() && !config.longStackTraces) {
                 throw new Error(LONG_STACK_TRACES_ERROR);
             }
             Promise.prototype._captureStackTrace = Promise_captureStackTrace;
@@ -251,9 +251,9 @@ Promise.config = function(opts) {
         }
     }
     if ("cancellation" in opts && opts.cancellation && !config.cancellation) {
-        if (async.haveItemsQueued()) {
+        if (async.areItemsQueued()) {
             throw new Error(
-                "cannot enable cancellation after promises are in use");
+                "cannot enable cancellation while promises are in use");
         }
         Promise.prototype._clearCancellationData =
             cancellationClearCancellationData;

--- a/src/promise.js
+++ b/src/promise.js
@@ -250,6 +250,10 @@ Promise.setBatchSize = function(batchSize) {
     return async.setBatchSize(batchSize);
 };
 
+Promise.fullyDrainQueues = function() {
+    async._fullyDrainQueues();
+};
+
 Promise.prototype._then = function (
     didFulfill,
     didReject,


### PR DESCRIPTION
When running unit tests, we sometimes want to turn on longStackTraces to capture callstacks for promises - it's very useful for debugging. However, always turning this on causes test times to double and causes tests to time out on some of our CI jobs (e.g. IE). Therefore, we want the ability to strategically turn this on just for some portion of code that we are trying to debug (e.g. just for the TileView tests). Bluebird currently doesn't allow the .longStackTraces property to change after initialization. In this change, we relax that restriction, but we make sure Bluebird queues are empty (no outstanding promises) before longStackTraces can be changed.