### PR TITLE
Revert long stack traces from bluebird...

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -167,6 +167,7 @@ Async.prototype.invokeFirst = function (fn, receiver, arg) {
 Async.prototype._drainQueue = function(queue, itemsToProcess) {
     ASSERT(itemsToProcess >= 0);
     while (queue.length() > 0) {
+
         if (itemsToProcess === 0) {
             // can not process any more items
             // in this frame.
@@ -201,9 +202,10 @@ Async.prototype._drainQueues = function (itemsToProcess) {
 };
 
 Async.prototype._fullyDrainQueues = function () {
-    this._drainQueue(this._normalQueue);
+    this._drainQueue(this._normalQueue, this._normalQueue.length());
     this._reset();
-    this._drainQueue(this._lateQueue);
+    this._drainQueue(this._lateQueue, this._lateQueue.length());
+    ASSERT(!this.areItemsQueued());
 };
 
 Async.prototype._queueTick = function () {

--- a/src/constants.js
+++ b/src/constants.js
@@ -122,7 +122,7 @@ CONSTANT(CONSTRUCT_ERROR_INVOCATION, "the promise constructor cannot be invoked 
     See http://goo.gl/MqrFmX\n");
 CONSTANT(NOT_GENERATOR_ERROR, "generatorFunction must be a function\n\n\
     See http://goo.gl/MqrFmX\n");
-CONSTANT(LONG_STACK_TRACES_ERROR, "cannot enable long stack traces while promises are in use\n\n\
+CONSTANT(LONG_STACK_TRACES_ERROR, "cannot enable long stack traces after promises have been created\n\n\
     See http://goo.gl/MqrFmX\n");
 CONSTANT(INSPECTION_VALUE_ERROR, "cannot get fulfillment value of a non-fulfilled promise\n\n\
     See http://goo.gl/MqrFmX\n");

--- a/src/debuggability.js
+++ b/src/debuggability.js
@@ -117,7 +117,7 @@ Promise.enableHadronTestTracking = function (enable) {
 
 var disableLongStackTraces = function() {};
 Promise.longStackTraces = function () {
-    if (async.areItemsQueued() && !config.longStackTraces) {
+    if (async.haveItemsQueued() && !config.longStackTraces) {
         throw new Error(LONG_STACK_TRACES_ERROR);
     }
     if (!config.longStackTraces && longStackTracesIsSupported()) {
@@ -125,7 +125,7 @@ Promise.longStackTraces = function () {
         var Promise_attachExtraTrace = Promise.prototype._attachExtraTrace;
         config.longStackTraces = true;
         disableLongStackTraces = function() {
-            if (async.areItemsQueued() && !config.longStackTraces) {
+            if (async.haveItemsQueued() && !config.longStackTraces) {
                 throw new Error(LONG_STACK_TRACES_ERROR);
             }
             Promise.prototype._captureStackTrace = Promise_captureStackTrace;
@@ -251,9 +251,9 @@ Promise.config = function(opts) {
         }
     }
     if ("cancellation" in opts && opts.cancellation && !config.cancellation) {
-        if (async.areItemsQueued()) {
+        if (async.haveItemsQueued()) {
             throw new Error(
-                "cannot enable cancellation while promises are in use");
+                "cannot enable cancellation after promises are in use");
         }
         Promise.prototype._clearCancellationData =
             cancellationClearCancellationData;

--- a/src/promise.js
+++ b/src/promise.js
@@ -250,10 +250,6 @@ Promise.setBatchSize = function(batchSize) {
     return async.setBatchSize(batchSize);
 };
 
-Promise.fullyDrainQueues = function() {
-    async._fullyDrainQueues();
-};
-
 Promise.prototype._then = function (
     didFulfill,
     didReject,


### PR DESCRIPTION
No longer used/referenced in hadron, so merges:
- 09b73032dd0e0dbc45c1d19ebf09e4e09e410e6e
- 1e6eab6eb1e77351db639941aa42bbcdb8e8eca4
 are no longer needed.

[git diff 7234b67d351fe5850bd19cb556e03b69c060ce1a..origin/jrohde/revert-tracingchanges](https://github.com/HBOCodeLabs/bluebird/compare/7234b67d351fe5850bd19cb556e03b69c060ce1a...HBOCodeLabs:jrohde/revert-tracingchanges) to compare this branch with the merge previous to those listed above.